### PR TITLE
Add Nigiri as additional option for Regtest testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,14 +95,7 @@ bitcoin network.
    
 ## REGTEST Testing
 
-Install Docker on your machine and use one of the following methods (either `bitcoin-regtest-box` or `nigiri`)
-
-### Bitcoin Regtest Box
-
-Clone [bitcoin-regtest-box project](https://github.com/bitcoindevkit/bitcoin-regtest-box) and follow
-   [README.md](https://github.com/bitcoindevkit/bitcoin-regtest-box/blob/master/README.md) instructions to start 
-   localhost REGTEST bitcoind nodes.
-
+Install Docker and Docker Compose on your machine
 
 ### nigiri
 You can use 🍣 [Nigiri CLI](https://github.com/vulpemventures/nigiri) to spin-up a complete development environment in `regtest` that includes a `bitcoin` node, a Blockstream `electrs` explorer and the [`esplora`](https://github.com/blockstream/esplora) web-app to visualize blocks and transactions in the browser.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,43 @@ bitcoin network.
    
 ## REGTEST Testing
 
+### bitcoin-regtest-box
+
 1. Clone [bitcoin-regtest-box project](https://github.com/bitcoindevkit/bitcoin-regtest-box) and follow
    [README.md](https://github.com/bitcoindevkit/bitcoin-regtest-box/blob/master/README.md) instructions to start 
    localhost REGTEST bitcoind nodes.
+
+
+### nigiri
+
+If you have already installed Docker on your machine, you can also use 🍣 [Nigiri CLI](https://github.com/vulpemventures/nigiri) to spin-up a complete development environment in `regtest` that includes a `bitcoin` node, a Blockstream `electrs` explorer and the [`esplora`](https://github.com/blockstream/esplora) web-app to visualize blocks and transactions in the browser.
+
+#### Install 🍣 Nigiri
+```bash
+$ curl https://getnigiri.vulpem.com | bash
+```
+
+#### Start
+```
+$ nigiri start
+```
+
+This will start the following interfaces:
+
+* Bitcoin 
+  * RPC host:port `localhost:18443`
+  * RPC user `admin1`
+  * RPC password `123`
+
+* Electrs
+  * REST `localhost:3000`
+  * Faucet `curl -X POST --data '{"address": "btcAddrs"}' http://localhost:3000/faucet`
+
+* Esplora
+  * From the browser `http://localhost:5000`
+
+
+#### Stop
+```
+$ nigiri stop
+```

--- a/README.md
+++ b/README.md
@@ -95,16 +95,17 @@ bitcoin network.
    
 ## REGTEST Testing
 
-### bitcoin-regtest-box
+Install Docker on your machine and use one of the following methods (either `bitcoin-regtest-box` or `nigiri`)
 
-1. Clone [bitcoin-regtest-box project](https://github.com/bitcoindevkit/bitcoin-regtest-box) and follow
+### Bitcoin Regtest Box
+
+Clone [bitcoin-regtest-box project](https://github.com/bitcoindevkit/bitcoin-regtest-box) and follow
    [README.md](https://github.com/bitcoindevkit/bitcoin-regtest-box/blob/master/README.md) instructions to start 
    localhost REGTEST bitcoind nodes.
 
 
 ### nigiri
-
-If you have already installed Docker on your machine, you can also use 🍣 [Nigiri CLI](https://github.com/vulpemventures/nigiri) to spin-up a complete development environment in `regtest` that includes a `bitcoin` node, a Blockstream `electrs` explorer and the [`esplora`](https://github.com/blockstream/esplora) web-app to visualize blocks and transactions in the browser.
+You can use 🍣 [Nigiri CLI](https://github.com/vulpemventures/nigiri) to spin-up a complete development environment in `regtest` that includes a `bitcoin` node, a Blockstream `electrs` explorer and the [`esplora`](https://github.com/blockstream/esplora) web-app to visualize blocks and transactions in the browser.
 
 #### Install 🍣 Nigiri
 ```bash

--- a/README.md
+++ b/README.md
@@ -134,5 +134,5 @@ This will start the following interfaces:
 
 #### Stop
 ```
-$ nigiri stop
+$ nigiri stop --delete
 ```


### PR DESCRIPTION
It could be useful especially for newcomers to Bitcoin development, to have an easy way to spin-up a local box with Bitcoin, Electrs, and Esplora frontend. Nigiri CLI it's the perfect solution batteries included (it features a faucet on the Electrs interface and automatic block mining when a tx is pushed)

I added the section that describes the steps to get it up and running.

PS: I understand if it could be out of scope, but I found it useful for people who don't want to set up too much stuff for regtest environment.